### PR TITLE
Replacing unofficial short-hand and improving the README

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -37,7 +37,7 @@ Claude will read this index and know where to find detailed information when nee
 
 - **`EQUILIBRIUM_IMPLEMENTATION.md`** - Equilibrium mapper implementation details
   - Field-by-field mapping documentation
-  - MDS+ paths and transforms
+  - MDSplus paths and transforms
   - Ragged array handling
   - Test configuration
 

--- a/CI/generate_docs.py
+++ b/CI/generate_docs.py
@@ -32,9 +32,9 @@ def yaml_to_markdown(yaml_file: Path, output_dir: Path):
         ])
         
         if 'mds_path' in entry_data:
-            md_lines.append(f"**MDS+ Path:** `{entry_data['mds_path']}`  ")
+            md_lines.append(f"**MDSplus Path:** `{entry_data['mds_path']}`  ")
         if 'mds_paths' in entry_data:
-            md_lines.append("**MDS+ Paths:**")
+            md_lines.append("**MDSplus Paths:**")
             for path in entry_data['mds_paths']:
                 md_lines.append(f"- `{path}`")
         

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ Claude will read the OMAS implementation and create:
 - YAML field list entries
 - Test configuration mappings
 
+For most mappings the only changes that should be required are:
+- Creating a python file with the mappings and associated yaml settings in 'ids/' (2 files)
+- Importing the mapper and registering it in `composer.py` (2 lines)
+- Creating a the test files and settings `test_*.yaml`, `test_*_requirements.py`, and `test_*_composition.py` (3 files)
+
 #### 2. Test and iterate
 
 Use VSCode Test Explorer to run tests (see [VSCode Setup](#vscode-setup) above):

--- a/docs/ece.yaml
+++ b/docs/ece.yaml
@@ -4,15 +4,15 @@
 system_overview: |
   ECE measures electron temperature via cyclotron emission.
   - Two sampling modes: standard and fast (high frequency)
-  - Channels numbered 1-NUMCH in MDS+, 0-indexed in IMAS
+  - Channels numbered 1-NUMCH in MDSplus, 0-indexed in IMAS
   - Line of sight geometry defined by phi, theta, and vertical position
 
 special_considerations:
-  - Fast ECE mode uses different MDS+ nodes (TECEF prefix instead of TECE)
-  - Line of sight geometry is NOT stored in MDS+; computed from fixed points
+  - Fast ECE mode uses different MDSplus nodes (TECEF prefix instead of TECE)
+  - Line of sight geometry is NOT stored in MDSplus; computed from fixed points
   - Uncertainties are computed, not fetched (7% calibration + sqrt(T*1000))
-  - Time in MDS+ is milliseconds, converted to seconds
-  - Frequency in MDS+ is GHz, converted to Hz for IMAS
+  - Time in MDSplus is milliseconds, converted to seconds
+  - Frequency in MDSplus is GHz, converted to Hz for IMAS
 
 entries:
   ece._numch:
@@ -52,7 +52,7 @@ entries:
   ece._time_base:
     summary: Time base for ECE measurements
     description: |
-      In MDS+, time is stored as the dimension of channel data.
+      In MDSplus, time is stored as the dimension of channel data.
       We use TECE{fast_suffix}01 as the representative channel
       since all channels share the same time base.
     mds_path: dim_of(\ECE::TOP.TECE.TECE{fast_suffix}01)
@@ -79,7 +79,7 @@ entries:
     depends_on:
       - ece._numch
     uncertainty_calculation: |
-      NOT stored in MDS+. Computed from:
+      NOT stored in MDSplus. Computed from:
       - Calibration error: 7% (optimistic estimate)
       - Statistical error: sqrt(T_keV * 1000) from Poisson statistics
       - Combined: sqrt(abs(T_keV * 1000)) + 70 * abs(T_keV)
@@ -90,7 +90,7 @@ entries:
       Value: 0 (false) - ECE channels may have different time bases in principle,
       though in practice DIII-D ECE typically has uniform sampling.
       
-      This is a metadata field that requires no MDS+ fetches.
+      This is a metadata field that requires no MDSplus fetches.
     value: 0
     omas_path: ods['ece.ids_properties.homogeneous_time']
     stage: COMPUTED
@@ -98,9 +98,9 @@ entries:
   ece.line_of_sight.first_point.r:
     summary: Major radius of first point defining ECE line of sight
     description: |
-      Value: 2.5 m (outer wall location, not stored in MDS+)
+      Value: 2.5 m (outer wall location, not stored in MDSplus)
       This is a fixed geometric parameter for DIII-D ECE system.
-      No MDS+ data required - pure constant.
+      No MDSplus data required - pure constant.
     value: 2.5
     units: meters
     omas_path: ods['ece.line_of_sight.first_point.r']
@@ -132,9 +132,9 @@ entries:
   ece.line_of_sight.second_point.r:
     summary: Major radius of second point defining ECE line of sight
     description: |
-      Value: 0.8 m (approximate plasma center, not stored in MDS+)
+      Value: 0.8 m (approximate plasma center, not stored in MDSplus)
       This is a fixed geometric parameter for DIII-D ECE system.
-      No MDS+ data required - pure constant.
+      No MDSplus data required - pure constant.
     value: 0.8
     units: meters
     omas_path: ods['ece.line_of_sight.second_point.r']
@@ -169,7 +169,7 @@ entries:
       Format: ECE{channel_number}
       Example: ECE1, ECE2, ..., ECE40
       
-      Channel numbers are 1-indexed (matching MDS+ convention).
+      Channel numbers are 1-indexed (matching MDSplus convention).
       Only requires knowing NUMCH, not actual measurement data.
     format: ECE{1-indexed}
     omas_path: ods['ece']['channel'][i]['name']
@@ -178,12 +178,12 @@ entries:
       - ece._numch
       
   ece.channel.identifier:
-    summary: Channel identifiers matching MDS+ node names
+    summary: Channel identifiers matching MDSplus node names
     description: |
       Format: TECE{fast_suffix}{channel:02d}
       Examples: TECE01, TECE02, ..., TECEF01 (fast mode)
       
-      These identifiers match the MDS+ node names exactly.
+      These identifiers match the MDSplus node names exactly.
       Only requires knowing NUMCH, not actual measurement data.
     format: TECE{fast_suffix}{02d}
     omas_path: ods['ece']['channel'][i]['identifier']
@@ -197,7 +197,7 @@ entries:
       In DIII-D ECE, all channels share the same time base.
       Time is replicated for each channel in flat array format.
       
-      Conversion: MDS+ time (ms) / 1000 -> IMAS time (s)
+      Conversion: MDSplus time (ms) / 1000 -> IMAS time (s)
       
       This can be fetched independently of temperature data,
       useful for pre-allocating arrays or time-based queries.
@@ -259,7 +259,7 @@ entries:
       All other channel properties (name, frequency, geometry) can be queried
       without triggering this expensive data fetch.
       
-      Conversion: MDS+ (keV) * 1000 -> IMAS (eV)
+      Conversion: MDSplus (keV) * 1000 -> IMAS (eV)
       
       Uncertainties computed from:
       - Calibration error: 7% (optimistic)

--- a/docs/thomson_scattering.yaml
+++ b/docs/thomson_scattering.yaml
@@ -11,7 +11,7 @@ system_overview: |
   Revision: BLESSED (standard blessed data set)
 
 special_considerations:
-  - Multi-step MDS+ fetch required (calibration → hardware map → measurements)
+  - Multi-step MDSplus fetch required (calibration → hardware map → measurements)
   - Hardware maps stored in separate TSCAL tree, indexed by calibration number
   - Not all systems may be active for a given shot
   - Phi coordinate is negated and converted from degrees to radians
@@ -133,7 +133,7 @@ entries:
     summary: Time base for electron density measurements
     description: |
       All active systems share the same time base in DIII-D Thomson.
-      Time in MDS+ is in milliseconds, converted to seconds (divide by 1000).
+      Time in MDSplus is in milliseconds, converted to seconds (divide by 1000).
     mds_path: .TS.BLESSED.{SYSTEM}:TIME
     units: seconds
     conversion: ms to s (divide by 1000)

--- a/imas_composer/core.py
+++ b/imas_composer/core.py
@@ -66,7 +66,7 @@ class IDSEntrySpec:
         return self.documentation.get('description', '')
     
     def get_mds_paths(self) -> list[str]:
-        """Get list of MDS+ paths used by this entry"""
+        """Get list of MDSplus paths used by this entry"""
         doc = self.documentation
         if 'mds_path' in doc:
             return [doc['mds_path']]

--- a/imas_composer/ids/ec_launchers.py
+++ b/imas_composer/ids/ec_launchers.py
@@ -20,7 +20,7 @@ class ECLaunchersMapper(IDSMapper):
 
     def __init__(self):
         """Initialize EC launchers mapper."""
-        # MDS+ path prefixes
+        # MDSplus path prefixes
         self.setup_node = '.ECH.'
 
         # Initialize base class (loads config, static_values, supported_fields)
@@ -276,7 +276,7 @@ class ECLaunchersMapper(IDSMapper):
         Args:
             shot: Shot number
             raw_data: Raw data dictionary
-            mds_path_template: MDS+ path template with {system_no} placeholder
+            mds_path_template: MDSplus path template with {system_no} placeholder
                               e.g., '.ECH.SYSTEM_{system_no}.GYROTRON.NAME'
 
         Returns:

--- a/imas_composer/ids/ece.py
+++ b/imas_composer/ids/ece.py
@@ -28,7 +28,7 @@ class ElectronCyclotronEmissionMapper(IDSMapper):
         self.fast_ece = fast_ece
         self.fast_suffix = 'F' if fast_ece else ''
 
-        # MDS+ path prefixes
+        # MDSplus path prefixes
         self.setup_node = '\\ECE::TOP.SETUP.'
         self.cal_node = f'\\ECE::TOP.CAL{self.fast_suffix}.'
         self.tece_node = f'\\ECE::TOP.TECE.TECE{self.fast_suffix}'
@@ -40,7 +40,7 @@ class ElectronCyclotronEmissionMapper(IDSMapper):
         self._build_specs()
     
     def _get_numch_path(self) -> str:
-        """Get MDS+ path for NUMCH node."""
+        """Get MDSplus path for NUMCH node."""
         return f'{self.cal_node}NUMCH{self.fast_suffix}'
 
     def _build_specs(self):

--- a/imas_composer/ids/equilibrium.py
+++ b/imas_composer/ids/equilibrium.py
@@ -58,7 +58,7 @@ class EquilibriumMapper(IDSMapper):
         """
         self.efit_tree = efit_tree
 
-        # MDS+ path prefixes
+        # MDSplus path prefixes
         self.geqdsk_node = f'\\{efit_tree}::TOP.RESULTS.GEQDSK'
         self.aeqdsk_node = f'\\{efit_tree}::TOP.RESULTS.AEQDSK'
         self.measurements_node = f'\\{efit_tree}::TOP.MEASUREMENTS'
@@ -2946,7 +2946,7 @@ class EquilibriumMapper(IDSMapper):
 
         Args:
             shot: Shot number
-            raw_data: Dictionary containing fetched MDS+ data
+            raw_data: Dictionary containing fetched MDSplus data
 
         Returns:
             COCOS number (1, 3, 5, or 7 typically)
@@ -2983,7 +2983,7 @@ class EquilibriumMapper(IDSMapper):
         Args:
             data: Data to transform
             shot: Shot number
-            raw_data: Dictionary containing fetched MDS+ data (for COCOS identification)
+            raw_data: Dictionary containing fetched MDSplus data (for COCOS identification)
             ids_path: IDS path to determine transformation type
 
         Returns:

--- a/imas_composer/ids/thomson_scattering.py
+++ b/imas_composer/ids/thomson_scattering.py
@@ -29,19 +29,19 @@ class ThomsonScatteringMapper(IDSMapper):
         self._build_specs()
 
     def _get_calib_nums_path(self) -> str:
-        """Get MDS+ path for calibration numbers."""
+        """Get MDSplus path for calibration numbers."""
         return f'.ts.{self.REVISION}.header.calib_nums'
 
     def _get_system_coordinate_path(self, system: str, coordinate: str) -> str:
-        """Get MDS+ path for system coordinate (R, Z, PHI)."""
+        """Get MDSplus path for system coordinate (R, Z, PHI)."""
         return f'.TS.{self.REVISION}.{system}:{coordinate}'
 
     def _get_system_measurement_path(self, system: str, quantity: str) -> str:
-        """Get MDS+ path for system measurement (DENSITY, TEMP, TIME, etc)."""
+        """Get MDSplus path for system measurement (DENSITY, TEMP, TIME, etc)."""
         return f'.TS.{self.REVISION}.{system}:{quantity}'
 
     def _get_hwmap_path(self, system: str) -> str:
-        """Get MDS+ path for hardware map."""
+        """Get MDSplus path for hardware map."""
         return f'.{system}.hwmapints'
     
     def _build_specs(self):
@@ -378,7 +378,7 @@ class ThomsonScatteringMapper(IDSMapper):
 
         Args:
             shot: Shot number
-            raw_data: Raw MDS+ data
+            raw_data: Raw MDSplus data
 
         Returns:
             Awkward array with ragged time data per channel (milliseconds)
@@ -420,9 +420,9 @@ class ThomsonScatteringMapper(IDSMapper):
 
         Args:
             shot: Shot number
-            raw_data: Raw MDS+ data
+            raw_data: Raw MDSplus data
             measurement: IMAS measurement name (e.g., 'n_e', 't_e')
-            quantity: MDS+ quantity name (e.g., 'DENSITY', 'TEMP')
+            quantity: MDSplus quantity name (e.g., 'DENSITY', 'TEMP')
 
         Returns:
             Awkward array with ragged measurement data per channel
@@ -463,9 +463,9 @@ class ThomsonScatteringMapper(IDSMapper):
 
         Args:
             shot: Shot number
-            raw_data: Raw MDS+ data
+            raw_data: Raw MDSplus data
             measurement: IMAS measurement name (e.g., 'n_e', 't_e')
-            quantity: MDS+ quantity name (e.g., 'DENSITY', 'TEMP')
+            quantity: MDSplus quantity name (e.g., 'DENSITY', 'TEMP')
 
         Returns:
             Awkward array with ragged uncertainty data per channel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,7 @@ def load_ids_fields(ids_name):
 
 def fetch_requirements(requirements: list[Requirement]) -> dict:
     """
-    Fetch multiple requirements from MDS+ in a single query.
+    Fetch multiple requirements from MDSplus in a single query.
 
     Args:
         requirements: List of Requirement objects to fetch
@@ -251,7 +251,7 @@ def resolve_and_compose(composer, ids_path, shot=REFERENCE_SHOT):
         # Fetch requirements
         fetched = fetch_requirements(requirements)
 
-        # Check if any fetched values are exceptions (from failed MDS+ access)
+        # Check if any fetched values are exceptions (from failed MDSplus access)
         for key, value in fetched.items():
             if isinstance(value, Exception):
                 raise RuntimeError(f"Failed to fetch requirement {key}: {value}") from value
@@ -278,12 +278,12 @@ def resolve_and_compose(composer, ids_path, shot=REFERENCE_SHOT):
 
 def _matches_optional_pattern(mds_path, pattern):
     """
-    Check if an MDS path matches an optional requirement pattern.
+    Check if an MDSplus path matches an optional requirement pattern.
 
     Supports {system_no} placeholder for dynamic system numbers.
 
     Args:
-        mds_path: Actual MDS path (e.g., '.ECH.SYSTEM_1.ANTENNA.GB_RCURVE')
+        mds_path: Actual MDSplus path (e.g., '.ECH.SYSTEM_1.ANTENNA.GB_RCURVE')
         pattern: Pattern with placeholders (e.g., '.ECH.SYSTEM_{system_no}.ANTENNA.GB_RCURVE')
 
     Returns:
@@ -475,15 +475,15 @@ def run_requirements_resolution(ids_path, composer, shot=REFERENCE_SHOT, max_ste
             assert hasattr(req, 'shot'), "Requirement must have shot"
             assert hasattr(req, 'treename'), "Requirement must have treename"
 
-            # Check if this specific MDS+ path is in the allow_different_shot list
-            # allow_different_shot contains MDS+ paths (e.g., '.ts.BLESSED.header.calib_nums')
+            # Check if this specific MDSplus path is in the allow_different_shot list
+            # allow_different_shot contains MDSplus paths (e.g., '.ts.BLESSED.header.calib_nums')
             is_calibration_data = req.mds_path in allow_different_shot
 
-            # Check shot number (unless this MDS+ path is marked as calibration data)
+            # Check shot number (unless this MDSplus path is marked as calibration data)
             if not is_calibration_data:
                 assert req.shot == shot, (
                     f"Requirement shot must match requested shot. "
-                    f"Got {req.shot}, expected {shot} for MDS+ path '{req.mds_path}'. "
+                    f"Got {req.shot}, expected {shot} for MDSplus path '{req.mds_path}'. "
                     f"If this is expected (e.g., calibration data), add '{req.mds_path}' "
                     f"to allow_different_shot in test_config_{ids_name}.yaml"
                 )

--- a/tests/test_config_core_profiles.yaml
+++ b/tests/test_config_core_profiles.yaml
@@ -5,7 +5,7 @@ field_exceptions: {}
 
 # Requirement validation settings
 requirement_validation:
-  # MDS+ paths that use calibration data (shot 0 or cal_set), not the requested shot
+  # MDSplus paths that use calibration data (shot 0 or cal_set), not the requested shot
   allow_different_shot: []
 
 # OMAS path mapping

--- a/tests/test_config_ec_launchers.yaml
+++ b/tests/test_config_ec_launchers.yaml
@@ -20,9 +20,9 @@ field_shot_exclusions:
 
 # Requirement validation settings
 requirement_validation:
-  # MDS+ paths that use setup/calibration data (shot 0), not the requested shot
+  # MDSplus paths that use setup/calibration data (shot 0), not the requested shot
   allow_different_shot: []
-  # Optional MDS+ paths that may not exist (exceptions are allowed)
+  # Optional MDSplus paths that may not exist (exceptions are allowed)
   optional_requirements:
     - '.ECH.SYSTEM_{system_no}.ANTENNA.GB_RCURVE'
     - '.ECH.SYSTEM_{system_no}.ANTENNA.GB_WAIST'

--- a/tests/test_config_ece.yaml
+++ b/tests/test_config_ece.yaml
@@ -5,7 +5,7 @@ field_exceptions: {}
 
 # Requirement validation settings
 requirement_validation:
-  # MDS+ paths that use calibration/setup data (shot 0), not the requested shot
+  # MDSplus paths that use calibration/setup data (shot 0), not the requested shot
   allow_different_shot: []
 # OMAS path mapping
 # Maps imas_composer notation to OMAS notation for fetching reference data

--- a/tests/test_config_thomson_scattering.yaml
+++ b/tests/test_config_thomson_scattering.yaml
@@ -5,7 +5,7 @@ field_exceptions: {}
 
 # Requirement validation settings
 requirement_validation:
-  # MDS+ paths that use calibration data (shot 0 or cal_set), not the requested shot
+  # MDSplus paths that use calibration data (shot 0 or cal_set), not the requested shot
   allow_different_shot:
     - '.ts.BLESSED.header.calib_nums'  # Calibration numbers (shot 0)
     - '.TANGENTIAL.hwmapints'  # Hardware maps use cal_set shot


### PR DESCRIPTION
Somehow Claude adopted the bad habit of referring to MDSplus as MDS+ (I blame the ./claude/README.md). Trying to stop this before it proliferates further.

Also added a note to the README about which files should be created or edited when adding a new mapping. This hopefully helps identify when larger framework changes are being made.