### PR TITLE
Remove the performative `_thermal` from electrons.density

### DIFF
--- a/imas_composer/ids/core_profiles.yaml
+++ b/imas_composer/ids/core_profiles.yaml
@@ -29,11 +29,11 @@ fields:
     trees: [OMFIT_PROFS]
 
   # Electrons - all trees
-  - profiles_1d.electrons.density_thermal
+  - profiles_1d.electrons.density
   - profiles_1d.electrons.temperature
 
   # Electrons - OMFIT_PROFS only (uncertainties)
-  - field: profiles_1d.electrons.density_thermal_error_upper
+  - field: profiles_1d.electrons.density_error_upper
     trees: [OMFIT_PROFS]
   - field: profiles_1d.electrons.temperature_error_upper
     trees: [OMFIT_PROFS]

--- a/imas_composer/ids/core_profiles_omfit.yaml
+++ b/imas_composer/ids/core_profiles_omfit.yaml
@@ -22,8 +22,8 @@ fields:
   - profiles_1d.grid.rho_pol_norm
 
   # Electrons
-  - profiles_1d.electrons.density_thermal
-  - profiles_1d.electrons.density_thermal_error_upper
+  - profiles_1d.electrons.density
+  - profiles_1d.electrons.density_error_upper
   - profiles_1d.electrons.temperature
   - profiles_1d.electrons.temperature_error_upper
 

--- a/imas_composer/ids/core_profiles_zipfit.py
+++ b/imas_composer/ids/core_profiles_zipfit.py
@@ -226,11 +226,11 @@ class CoreProfilesZipfitMapper(IDSMapper):
             "core_profiles.profiles_1d._carbon_rotation_rho"
         ]
 
-        self.specs["core_profiles.profiles_1d.electrons.density_thermal"] = IDSEntrySpec(
+        self.specs["core_profiles.profiles_1d.electrons.density"] = IDSEntrySpec(
             stage=RequirementStage.COMPUTED,
             depends_on=density_deps,
             compose=self._compose_density_thermal,
-            ids_path="core_profiles.profiles_1d.electrons.density_thermal",
+            ids_path="core_profiles.profiles_1d.electrons.density",
             docs_file=self.DOCS_PATH
         )
 
@@ -286,7 +286,7 @@ class CoreProfilesZipfitMapper(IDSMapper):
 
         # Ion[0]: density_thermal (calculated from quasineutrality: n_D = n_e - 6*n_C)
         deuterium_deps = [
-            "core_profiles.profiles_1d.electrons.density_thermal",
+            "core_profiles.profiles_1d.electrons.density",
             "core_profiles.profiles_1d.ion.1.density_thermal"
         ]
 
@@ -530,10 +530,10 @@ class CoreProfilesZipfitMapper(IDSMapper):
 
     def _compose_density_thermal(self, shot: int, raw_data: Dict[str, Any]) -> np.ndarray:
         """
-        Compose electrons.density_thermal.
+        Compose electrons.density.
 
         For ZIPFIT (d3d.py:1666, 1687, 1693, 1710):
-            query["electrons.density_thermal"] = "\\TOP.PROFILES.EDENSFIT"
+            query["electrons.density"] = "\\TOP.PROFILES.EDENSFIT"
             data[entry] *= 1E19  # in [m^-3]
             # Interpolate to common grid
 
@@ -831,7 +831,7 @@ class CoreProfilesZipfitMapper(IDSMapper):
         For ZIPFIT (d3d.py:1712):
             # deuterium from quasineutrality
             ods[f"{sh}[{i_time}].ion[0].density_thermal"] =
-                ods[f"{sh}[{i_time}].electrons.density_thermal"] -
+                ods[f"{sh}[{i_time}].electrons.density"] -
                 ods[f"{sh}[{i_time}].ion[1].density_thermal"] * 6
 
         Returns:

--- a/imas_composer/ids/core_profiles_zipfit.yaml
+++ b/imas_composer/ids/core_profiles_zipfit.yaml
@@ -20,7 +20,7 @@ fields:
   - profiles_1d.grid.rho_tor_norm
 
   # Electrons
-  - profiles_1d.electrons.density_thermal
+  - profiles_1d.electrons.density
   - profiles_1d.electrons.temperature
 
   # Ion[0] - Deuterium

--- a/tests/test_config_core_profiles.yaml
+++ b/tests/test_config_core_profiles.yaml
@@ -33,11 +33,11 @@ omas_path_map:
   core_profiles.profiles_1d.grid.rho_pol_norm: core_profiles.profiles_1d.:.grid.rho_pol_norm
 
   # Electron profiles
-  core_profiles.profiles_1d.electrons.density_thermal: core_profiles.profiles_1d.:.electrons.density_thermal
+  core_profiles.profiles_1d.electrons.density: core_profiles.profiles_1d.:.electrons.density
   core_profiles.profiles_1d.electrons.temperature: core_profiles.profiles_1d.:.electrons.temperature
 
   # Electron uncertainties (OMFIT_PROFS only)
-  core_profiles.profiles_1d.electrons.density_thermal_error_upper: core_profiles.profiles_1d.:.electrons.density_thermal_error_upper
+  core_profiles.profiles_1d.electrons.density_error_upper: core_profiles.profiles_1d.:.electrons.density_error_upper
   core_profiles.profiles_1d.electrons.temperature_error_upper: core_profiles.profiles_1d.:.electrons.temperature_error_upper
 
   # Electron fit fields (OMFIT_PROFS only)


### PR DESCRIPTION
This remove `electrons.density_thermal` and replaces it with the normal `electrons.density`. None of our workflows makes this distinction and even if they did the distinction between `thermal` and `density` would be of the order of 0.1% in my PhD experiments that tried their very best at being non-thermal. Making this distinction is performative at best and misleading at worst.