### PR TITLE
Add summary IDS mapper: TRANSPORT.GLOBAL.TIMES.TAUE → tau_energy

### DIFF
--- a/imas_composer/ids/summary.py
+++ b/imas_composer/ids/summary.py
@@ -1,0 +1,104 @@
+"""
+Summary IDS Mapping for DIII-D
+
+Maps global scalar quantities from the DIII-D TRANSPORT MDSplus tree
+to the IMAS summary IDS.
+
+The TRANSPORT tree stores time-traced global quantities computed by
+transport analysis codes (e.g. TRANSP, ONETWO).  The GLOBAL subtree
+contains quantities derived from the full shot analysis, including
+confinement times, stored energies, and power balance terms.
+
+Currently implemented:
+  - summary.global_quantities.tau_energy.value  ← TRANSPORT.GLOBAL.TIMES.TAUE
+  - summary.global_quantities.tau_energy.time   ← dim_of(TRANSPORT.GLOBAL.TIMES.TAUE)
+"""
+
+from typing import Dict, List
+
+import numpy as np
+
+from ..core import IDSEntrySpec, Requirement, RequirementStage
+from .base import IDSMapper
+
+
+class SummaryMapper(IDSMapper):
+    """Maps DIII-D TRANSPORT tree data to the IMAS summary IDS."""
+
+    CONFIG_PATH = "summary.yaml"
+
+    def __init__(self, **kwargs):
+        """Initialize Summary mapper."""
+        super().__init__()
+        self._build_specs()
+
+    def _build_specs(self):
+        """Build all IDS entry specifications."""
+
+        # --- internal: fetch TAUE signal from TRANSPORT tree ---
+        self.specs["summary._taue"] = IDSEntrySpec(
+            stage=RequirementStage.DIRECT,
+            static_requirements=[
+                Requirement(r"\TRANSPORT::TOP.GLOBAL.TIMES.TAUE", 0, "TRANSPORT"),
+            ],
+            ids_path="summary._taue",
+            docs_file=self.CONFIG_PATH,
+        )
+
+        self.specs["summary._taue_time"] = IDSEntrySpec(
+            stage=RequirementStage.DIRECT,
+            static_requirements=[
+                Requirement(
+                    r"dim_of(\TRANSPORT::TOP.GLOBAL.TIMES.TAUE, 0) / 1e3",
+                    0,
+                    "TRANSPORT",
+                ),
+            ],
+            ids_path="summary._taue_time",
+            docs_file=self.CONFIG_PATH,
+        )
+
+        # --- public: summary.global_quantities.tau_energy.value ---
+        self.specs["summary.global_quantities.tau_energy.value"] = IDSEntrySpec(
+            stage=RequirementStage.COMPUTED,
+            depends_on=["summary._taue"],
+            compose=self._compose_tau_energy_value,
+            ids_path="summary.global_quantities.tau_energy.value",
+            docs_file=self.CONFIG_PATH,
+        )
+
+        # --- public: summary.global_quantities.tau_energy.time ---
+        self.specs["summary.global_quantities.tau_energy.time"] = IDSEntrySpec(
+            stage=RequirementStage.COMPUTED,
+            depends_on=["summary._taue_time"],
+            compose=self._compose_tau_energy_time,
+            ids_path="summary.global_quantities.tau_energy.time",
+            docs_file=self.CONFIG_PATH,
+        )
+
+    def _compose_tau_energy_value(self, shot: int, raw_data: dict) -> np.ndarray:
+        """
+        Compose energy confinement time values (seconds).
+
+        TRANSPORT.GLOBAL.TIMES.TAUE is stored in seconds.
+        """
+        key = Requirement(
+            r"\TRANSPORT::TOP.GLOBAL.TIMES.TAUE", shot, "TRANSPORT"
+        ).as_key()
+        return np.asarray(raw_data[key], dtype=float)
+
+    def _compose_tau_energy_time(self, shot: int, raw_data: dict) -> np.ndarray:
+        """
+        Compose time base for tau_energy (seconds).
+
+        dim_of(..., 0) returns milliseconds; divide by 1e3 to convert to seconds.
+        """
+        key = Requirement(
+            r"dim_of(\TRANSPORT::TOP.GLOBAL.TIMES.TAUE, 0) / 1e3",
+            shot,
+            "TRANSPORT",
+        ).as_key()
+        return np.asarray(raw_data[key], dtype=float)
+
+    def get_specs(self) -> Dict[str, IDSEntrySpec]:
+        return self.specs

--- a/imas_composer/ids/summary.yaml
+++ b/imas_composer/ids/summary.yaml
@@ -1,0 +1,13 @@
+# Summary IDS Configuration for DIII-D
+#
+# The IMAS summary IDS collects global scalar quantities derived from
+# other diagnostics and analysis codes.  On DIII-D these quantities
+# are stored in the TRANSPORT MDSplus tree under the GLOBAL subtree.
+#
+# MDSplus tree: TRANSPORT
+# Subtree:      TRANSPORT.GLOBAL
+
+# Supported fields (complete list of implemented IDS paths)
+fields:
+  - global_quantities.tau_energy.value
+  - global_quantities.tau_energy.time

--- a/tests/test_config_summary.yaml
+++ b/tests/test_config_summary.yaml
@@ -1,0 +1,18 @@
+# Test configuration for Summary IDS
+
+# Fields to skip OMAS comparison for.
+# All summary fields are skipped because the summary IDS is a derived
+# quantity in OMAS (computed from stored energy and power balance) rather
+# than read directly from MDSplus.  The composition tests in
+# test_summary_composition.py verify the values directly instead.
+skip_fields:
+  global_quantities.tau_energy.value: "summary IDS is derived in OMAS, not read from MDSplus"
+  global_quantities.tau_energy.time: "summary IDS is derived in OMAS, not read from MDSplus"
+
+# Requirement validation settings
+requirement_validation:
+  # The TRANSPORT tree is queried with the actual shot number (not shot 0)
+  allow_different_shot: []
+
+# OMAS path mapping (unused — all fields skipped above)
+omas_path_map: {}

--- a/tests/test_summary_composition.py
+++ b/tests/test_summary_composition.py
@@ -1,0 +1,108 @@
+"""
+Test Summary IDS data composition.
+
+Verifies that summary.global_quantities.tau_energy.value and .time
+are correctly fetched from the DIII-D TRANSPORT MDSplus tree and
+returned as numpy arrays with physically reasonable values.
+
+TRANSPORT.GLOBAL.TIMES.TAUE stores the energy confinement time in seconds
+as computed by the transport analysis.  For DIII-D H-mode plasmas a
+typical value is 0.05 – 0.40 s.
+
+The composition tests do not compare against OMAS because the summary IDS
+is a derived quantity in OMAS (computed from stored energy and power balance)
+rather than read directly from MDSplus.  Instead we check:
+  - The output is a 1-D numpy array of finite floats
+  - The time array is monotonically increasing and in seconds (not ms)
+  - tau_energy values are in a physically plausible range for DIII-D
+"""
+import numpy as np
+import pytest
+
+from tests.conftest import REFERENCE_SHOT, load_ids_fields
+from imas_composer import ImasComposer
+
+
+@pytest.mark.parametrize('ids_path', load_ids_fields('summary'))
+def test_can_resolve_requirements(ids_path, composer):
+    """Requirements resolve without error."""
+    from tests.conftest import run_requirements_resolution
+    run_requirements_resolution(ids_path, composer, REFERENCE_SHOT)
+
+
+def test_tau_energy_value_is_array(composer):
+    """summary.global_quantities.tau_energy.value returns a numpy array."""
+    result = composer.simple_load(
+        ['summary.global_quantities.tau_energy.value'], REFERENCE_SHOT
+    )
+    tau_e = result['summary.global_quantities.tau_energy.value']
+    assert isinstance(tau_e, np.ndarray), "tau_energy.value should be a numpy array"
+    assert tau_e.ndim == 1, "tau_energy.value should be 1-D (time trace)"
+
+
+def test_tau_energy_value_finite(composer):
+    """tau_energy.value contains only finite values."""
+    result = composer.simple_load(
+        ['summary.global_quantities.tau_energy.value'], REFERENCE_SHOT
+    )
+    tau_e = result['summary.global_quantities.tau_energy.value']
+    assert np.all(np.isfinite(tau_e)), "tau_energy.value should contain only finite values"
+
+
+def test_tau_energy_value_positive(composer):
+    """tau_energy.value is strictly positive (confinement time cannot be negative)."""
+    result = composer.simple_load(
+        ['summary.global_quantities.tau_energy.value'], REFERENCE_SHOT
+    )
+    tau_e = result['summary.global_quantities.tau_energy.value']
+    assert np.all(tau_e > 0), "tau_energy.value should be strictly positive"
+
+
+def test_tau_energy_value_plausible_range(composer):
+    """tau_energy mean is in the DIII-D range 0.01 – 1.0 s."""
+    result = composer.simple_load(
+        ['summary.global_quantities.tau_energy.value'], REFERENCE_SHOT
+    )
+    tau_e = result['summary.global_quantities.tau_energy.value']
+    mean_tau = float(np.mean(tau_e))
+    assert 0.01 < mean_tau < 1.0, (
+        f"Mean tau_energy = {mean_tau:.4f} s is outside plausible DIII-D range [0.01, 1.0] s"
+    )
+
+
+def test_tau_energy_time_is_seconds(composer):
+    """tau_energy.time values are in seconds (not milliseconds)."""
+    result = composer.simple_load(
+        ['summary.global_quantities.tau_energy.time'], REFERENCE_SHOT
+    )
+    t = result['summary.global_quantities.tau_energy.time']
+    assert isinstance(t, np.ndarray)
+    # Shot duration on DIII-D is < 10 s; if values > 1000 the unit is ms
+    assert np.max(t) < 100.0, (
+        f"tau_energy.time max = {np.max(t):.1f} — expected seconds, got milliseconds?"
+    )
+
+
+def test_tau_energy_time_monotonic(composer):
+    """tau_energy.time is monotonically increasing."""
+    result = composer.simple_load(
+        ['summary.global_quantities.tau_energy.time'], REFERENCE_SHOT
+    )
+    t = result['summary.global_quantities.tau_energy.time']
+    assert np.all(np.diff(t) > 0), "tau_energy.time should be monotonically increasing"
+
+
+def test_tau_energy_value_and_time_same_length(composer):
+    """tau_energy.value and .time have the same number of points."""
+    result = composer.simple_load(
+        [
+            'summary.global_quantities.tau_energy.value',
+            'summary.global_quantities.tau_energy.time',
+        ],
+        REFERENCE_SHOT,
+    )
+    tau_e = result['summary.global_quantities.tau_energy.value']
+    t     = result['summary.global_quantities.tau_energy.time']
+    assert len(tau_e) == len(t), (
+        f"tau_energy value length {len(tau_e)} != time length {len(t)}"
+    )

--- a/tests/test_summary_requirements.py
+++ b/tests/test_summary_requirements.py
@@ -1,0 +1,16 @@
+"""
+Test Summary IDS requirement resolution.
+
+Verifies that resolve() can fully resolve all requirements for each
+summary IDS field using the TRANSPORT MDSplus tree.
+"""
+import pytest
+
+from tests.conftest import REFERENCE_SHOT, load_ids_fields, run_requirements_resolution
+
+
+@pytest.mark.parametrize('ids_path', load_ids_fields('summary'))
+def test_can_resolve_requirements(ids_path, composer):
+    """Test that resolve() can fully resolve requirements for each summary field."""
+    resolution_steps = run_requirements_resolution(ids_path, composer, REFERENCE_SHOT)
+    print(f"\n{ids_path}: resolved in {resolution_steps} steps")


### PR DESCRIPTION
## Summary

- Adds `SummaryMapper` that maps DIII-D TRANSPORT MDSplus tree data to the IMAS `summary` IDS
- Implements `summary.global_quantities.tau_energy.value` and `summary.global_quantities.tau_energy.time`
- Follows the existing two-stage DIRECT→COMPUTED pattern used by all other mappers

## MDSplus mapping

| IMAS path | MDSplus expression | Tree |
|---|---|---|
| `summary.global_quantities.tau_energy.value` | `\TRANSPORT::TOP.GLOBAL.TIMES.TAUE` | TRANSPORT |
| `summary.global_quantities.tau_energy.time` | `dim_of(\TRANSPORT::TOP.GLOBAL.TIMES.TAUE, 0) / 1e3` | TRANSPORT |

`TAUE` is stored in seconds. The time dimension is stored in milliseconds and is converted to seconds on fetch.

## Motivation

The `summary` IDS was the last missing piece preventing the [TR-TSV](https://github.com/smithsp/tr-tsv) IPB98(y,2) confinement time model from comparing its predicted τ_E against the measured experimental value. With this mapper, the reference path `summary.global_quantities.tau_energy.value` becomes fetchable from MDSplus, enabling metric computation in the `confinement` validation category.

## Tests

- `tests/test_summary_requirements.py` — parametric test that each field's requirements resolve without error (follows the pattern of all other `test_*_requirements.py` files)
- `tests/test_summary_composition.py` — composition tests verifying:
  - output is a 1-D numpy array of finite, positive values
  - mean τ_E is in the plausible DIII-D range 0.01–1.0 s
  - time array is in seconds (not ms) and monotonically increasing
  - value and time arrays have the same length
- `tests/test_config_summary.yaml` — skips OMAS comparison (the `summary` IDS is derived/computed in OMAS rather than read directly from MDSplus, so there is no direct OMAS reference to compare against)

## Test plan

- [ ] Run `pytest tests/test_summary_requirements.py` on a machine with DIII-D MDSplus access (requires TRANSPORT tree for reference shots)
- [ ] Run `pytest tests/test_summary_composition.py` on same machine
- [ ] Verify `simple_load(['summary.global_quantities.tau_energy.value'], <shot>)` returns a sensible time trace for a known H-mode shot

🤖 Generated with [Claude Code](https://claude.ai/claude-code)