### PR TITLE
This is motivated by the queries timing out recently

### DIFF
--- a/plots/d3drdb.py
+++ b/plots/d3drdb.py
@@ -104,7 +104,7 @@ class D3DRDB:
             f"UID={self._username};"
             f"PWD={self._password};"
             "TDS_Version=7.0;"
-            "Login Timeout=30;"
+            "Login Timeout=60;"
         )
         self._cnxn = pyodbc.connect(conn_str)
         self._cursor = self._cnxn.cursor()

--- a/plots/iri_cake_viewer.py
+++ b/plots/iri_cake_viewer.py
@@ -207,7 +207,7 @@ class DataLoader(QtCore.QThread):
             self.error.emit(traceback.format_exc())
 
 
-RDB_TIMEOUT_MS = 10_000
+RDB_TIMEOUT_MS = 20_000
 
 
 class D3DrdbWorker(QtCore.QThread):
@@ -223,10 +223,10 @@ class D3DrdbWorker(QtCore.QThread):
         self._kwargs = kwargs
 
     def run(self):
-        try:
-            self.result.emit(self._fn(*self._args, **self._kwargs))
-        except Exception:
-            self.error.emit(traceback.format_exc())
+        # try:
+        self.result.emit(self._fn(*self._args, **self._kwargs))
+        # except Exception:
+        #     self.error.emit(traceback.format_exc())
 
 
 # ---------------------------------------------------------------------------

--- a/plots/iri_cake_viewer.py
+++ b/plots/iri_cake_viewer.py
@@ -223,10 +223,10 @@ class D3DrdbWorker(QtCore.QThread):
         self._kwargs = kwargs
 
     def run(self):
-        # try:
-        self.result.emit(self._fn(*self._args, **self._kwargs))
-        # except Exception:
-        #     self.error.emit(traceback.format_exc())
+        try:
+            self.result.emit(self._fn(*self._args, **self._kwargs))
+        except Exception:
+            self.error.emit(traceback.format_exc())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Yesterday the `CAKE_FDP_ida_lite` queries would time out. While this has been optimized on the rdb side a little more patience should not hurt.