### PR TITLE
This should fix the build of iri-cake-viewer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imas_composer"
-version = "0.2.2"
+version = "0.2.3"
 description = "A Python library for fetching DIII-D MDSplus data in IMAS (ITER Integrated Modelling & Analysis Suite) tensor (blocked data) format with ragged arrays instead of padding"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -86,7 +86,7 @@ Documentation = "https://github.com/DIII-D/imas_composer/blob/main/README.md"
 "Bug Tracker" = "https://github.com/DIII-D/imas_composer/issues"
 
 [tool.setuptools]
-packages = ["imas_composer", "imas_composer.ids", "imas_composer.plots"]
+packages = ["imas_composer", "imas_composer.ids", "imas_composer.plots", "imas_composer.rdb"]
 
 [tool.setuptools.package-data]
 imas_composer = ["ids/*.yaml", "cocos.yaml"]


### PR DESCRIPTION
The previous build ommitted rdb as a package and ws missing the __init__ in the rdb folder causing the build to fail to import imas_composer.rdb