### PR TITLE
Replace 0 error with inf for Ti/ni

### DIFF
--- a/imas_composer/ids/charge_exchange.py
+++ b/imas_composer/ids/charge_exchange.py
@@ -717,7 +717,9 @@ class ChargeExchangeMapper(IDSMapper):
             stat = self._lookup(raw_data, shot, self._cer_path(sub, ch, 'TEMP_ERR_PS'))
             sys = self._lookup(raw_data, shot, self._cer_path(sub, ch, 'TEMP_ERR'))
             stat_arr = np.atleast_1d(stat) if stat is not None else np.array([])
+            stat_arr[stat_arr <= 0] = np.inf
             sys_arr = np.atleast_1d(sys) if sys is not None else np.array([])
+            sys_arr[sys_arr <= 0] = np.inf
             result.append(np.stack([stat_arr, sys_arr]))
         return ak.Array(result)[:, None,...]
 
@@ -864,6 +866,7 @@ class ChargeExchangeMapper(IDSMapper):
             ich = array_order.index(f'{sub[0:4]}{ch}')
             ind = slice(indices[ich], indices[ich+1])
             val = np.atleast_1d(impdens[ind])
+            val[val <= 0] = np.inf
             result.append(val if len(val) > 0 else np.array([]))
         return ak.Array(result)[:, None,...]
 


### PR DESCRIPTION
IDA asserts whether any uncertainties are zero. Charge exchange does produce zero (or smaller) uncertainties. My proposed solution is to replace zero or smaller uncertainties to infinity with the argument that if we cannot quantify the uncertainty of a measurement properly we should reject it.