### PR TITLE
Fix two problems with pyprojet.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ plots = [
     "scipy",
     "contourpy",
     "pyodbc",
+    "freetds",
 ]
 
 # Development dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ plots = [
     "scipy",
     "contourpy",
     "pyodbc",
-    "freetds",
 ]
 
 # Development dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "imas_composer"
-version = "0.2.3"
+version = "0.2.4"
 description = "A Python library for fetching DIII-D MDSplus data in IMAS (ITER Integrated Modelling & Analysis Suite) tensor (blocked data) format with ragged arrays instead of padding"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -89,7 +89,7 @@ Documentation = "https://github.com/DIII-D/imas_composer/blob/main/README.md"
 packages = ["imas_composer", "imas_composer.ids", "imas_composer.plots", "imas_composer.rdb"]
 
 [tool.setuptools.package-data]
-imas_composer = ["ids/*.yaml", "cocos.yaml"]
+imas_composer = ["ids/*.yaml", "cocos.yaml", "machine_description/**/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
1. We were not exporting the `machine_description` folder into the package. This is something we need to remember when we add data files to this repo, they need to be also added to the `pyproject.toml` otherwise they get lost as soon as with don't `pip install -e  <>`.
2. Claude missed the freetds requirement since it is hidden at a level too deep for it to see.

Version number has been incremented. I will make a release as soon as this gets merged.